### PR TITLE
local runtime vs vercel 

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
   ],
   "routes": [
     {"src": "/(.*)", "dest": "src/app.py"}
-  ]
+  ],
+  "env": {
+    "LC_ALL": "C",
+    "LC_NUMERIC": "C",
+    "LANG": "C"
+  }
 }


### PR DESCRIPTION
Vercel’s Python runtime (serverless AWS Lambda-like environment) does not ship OS locale packs. The empty-string call setlocale(LC_NUMERIC, '') asks Python to use the process locale from environment variables, but those are either unset or point to a locale that doesn’t exist in the runtime. Hence the 500.
Why Vercel breaks while local works

On your machine: the locale referenced by '' resolves via your environment (e.g., en_US.UTF-8), and that locale is installed.
On Vercel: only the minimal C/POSIX locale is guaranteed, and many common locales are not installed. If LANG/LC_ALL resolve to something like en_US.UTF-8 without that locale being installed, setlocale raises.